### PR TITLE
Removing gRPC Client Libraries from Linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/gen/grpc linguist-vendored


### PR DESCRIPTION
This `.gitattributes` file will tell Linguist/GitHub to ignore the `/gen/grpc` directory, thus preventing GitHub from reporting that this repo is 39.6% C# and 36.1% Javascript