### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,6 @@ RUN go install ./...
 
 FROM alpine
 RUN apk add ca-certificates
-COPY --from=build-env /go/bin/* /usr/local/bin/*
+COPY --from=build-env /go/bin/ /usr/local/bin/
 WORKDIR /workspace
 ENTRYPOINT ["/usr/local/bin/graphik"]


### PR DESCRIPTION
- Remove use of wildcard/astericks characters when copying go binary from
  the build stage
  
  
  After I pulled the image from the remote image repository and attempted to run your project locally, I found the container was unable to start up successfully.
  
```
$ docker pull graphikdb/graphik:v0.10.0
v0.10.0: Pulling from graphikdb/graphik
Digest: sha256:96e05b6211c72750d8f089ae44222c56adfefe6dba6f277187cd7102b3e1e56c
Status: Image is up to date for graphikdb/graphik:v0.10.0
docker.io/graphikdb/graphik:v0.10.0
$ docker run -it graphikdb/graphik:v0.10.0
docker: Error response from daemon: OCI runtime create failed: container_linux.go:370: starting container process caused: exec: "/usr/local/bin/graphik": stat /usr/local/bin/graphik: no such file or directory: unknown.
```

After inspecting the Docker related files and the individual intermediate containers, I discovered the copy statement was copying and renaming the binary to '*' on the destination container. It appears Docker will recursively copy all files to the destination if a directory is specified in the source. If you explicitly tell docker to only copy a single file, then it will only copy that single file.

After updating the Dockerfile and rebuilding the image, the container will now recognize the appropriate binary path.

```
$ docker run -it xyzst/graphik sh
{"level":"error","ts":1608531801.165519,"msg":"empty open-id connect discovery --open-id","host":"8816e46234e0","service":"graphik","version":"0.10.0","usage":"open id connect discovery uri ex: https://accounts.google.com/.well-known/openid-configuration (env: GRAPHIK_OPEN_ID) (required)","goroutines":1}
```